### PR TITLE
Expose `*GraphRequest` functions

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -21,7 +21,8 @@ type Client interface {
 	// the credentials or if the credentials are still valid.
 	RefreshCredentials() error
 
-	httpClient() *http.Client
+	// HTTPClient returns the `*http.Client` to use for this Client.
+	HTTPClient() *http.Client
 }
 
 // RequestCredentials stores all the information necessary to authenticate a request with the

--- a/client/client.go
+++ b/client/client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"net/http"
 	"sync"
 	"time"
 )
@@ -19,6 +20,8 @@ type Client interface {
 	// RequestCredentials.AccessTokenExpiresAt field to determine whether it should actually refresh
 	// the credentials or if the credentials are still valid.
 	RefreshCredentials() error
+
+	httpClient() *http.Client
 }
 
 // RequestCredentials stores all the information necessary to authenticate a request with the

--- a/client/client.go
+++ b/client/client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"net/http"
 	"sync"
 	"time"
@@ -13,13 +14,13 @@ type Client interface {
 
 	// InitializeCredentials should make the initial requests necessary to establish the first set of
 	// authentication credentials within the Client.
-	InitializeCredentials() error
+	InitializeCredentials(context.Context) error
 
 	// RefreshCredentials should initiate an internal refresh of the request credentials inside this
 	// client. This refresh should, whenever possible, check the
 	// RequestCredentials.AccessTokenExpiresAt field to determine whether it should actually refresh
 	// the credentials or if the credentials are still valid.
-	RefreshCredentials() error
+	RefreshCredentials(context.Context) error
 
 	// HTTPClient returns the `*http.Client` to use for this Client.
 	HTTPClient() *http.Client

--- a/client/client.go
+++ b/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 )
@@ -32,4 +33,28 @@ type RequestCredentials struct {
 	AccessToken          string
 	AccessTokenExpiresAt time.Time
 	AccessTokenUpdating  sync.Mutex
+}
+
+// ConsentURL builds the consent URL needed to add this application to a target Azure domain.
+func ConsentURL(applicationID, redirectURI, state string) (*url.URL, error) {
+	consentURL, err := url.Parse("https://login.microsoftonline.com/common/adminconsent")
+	if err != nil {
+		return nil, err
+	}
+
+	query := url.Values{
+		"client_id": []string{applicationID},
+	}
+
+	if redirectURI != "" {
+		query.Set("redirect_uri", redirectURI)
+	}
+
+	if state != "" {
+		query.Set("state", state)
+	}
+
+	consentURL.RawQuery = query.Encode()
+
+	return consentURL, nil
 }

--- a/client/headless_client.go
+++ b/client/headless_client.go
@@ -124,3 +124,8 @@ func (h Headless) InitializeCredentials(ctx context.Context) error {
 func (h Headless) RefreshCredentials(ctx context.Context) error {
 	return h.InitializeCredentials(ctx)
 }
+
+// ConsentURL builds the consent URL needed to add this application to a target Azure domain.
+func (h Headless) ConsentURL(redirectURL, state string) (*url.URL, error) {
+	return ConsentURL(h.ApplicationID, redirectURL, state)
+}

--- a/client/headless_client.go
+++ b/client/headless_client.go
@@ -81,6 +81,7 @@ func (h Headless) InitializeCredentials(ctx context.Context) error {
 		return err
 	}
 	b, err := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
 	if err != nil {
 		return err
 	}

--- a/client/headless_client.go
+++ b/client/headless_client.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/mhoc/msgoraph/scopes"
@@ -59,24 +58,17 @@ func (h Headless) InitializeCredentials(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequestWithContext(
+	resp, err := postForm(
 		ctx,
-		http.MethodPost,
+		h.HTTPClient(),
 		tokenURI.String(),
-		strings.NewReader(
-			url.Values{
-				"client_id":     {h.ApplicationID},
-				"client_secret": {h.ApplicationSecret},
-				"grant_type":    {"client_credentials"},
-				"scope":         {"https://graph.microsoft.com/.default"},
-			}.Encode(),
-		),
+		url.Values{
+			"client_id":     {h.ApplicationID},
+			"client_secret": {h.ApplicationSecret},
+			"grant_type":    {"client_credentials"},
+			"scope":         {"https://graph.microsoft.com/.default"},
+		},
 	)
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	resp, err := h.HTTPClient().Do(req)
 	if err != nil {
 		return err
 	}

--- a/client/headless_client.go
+++ b/client/headless_client.go
@@ -22,7 +22,7 @@ type Headless struct {
 	RefreshToken       string
 	RequestCredentials *RequestCredentials
 	Scopes             scopes.Scopes
-	HTTPClient         *http.Client
+	Client             *http.Client
 }
 
 // NewHeadless creates a new headless connection.
@@ -32,12 +32,13 @@ func NewHeadless(applicationID string, applicationSecret string, scopes scopes.S
 		ApplicationSecret:  applicationSecret,
 		RequestCredentials: &RequestCredentials{},
 		Scopes:             scopes,
-		HTTPClient:         http.DefaultClient,
+		Client:             http.DefaultClient,
 	}
 }
 
-func (h Headless) httpClient() *http.Client {
-	return h.HTTPClient
+// HTTPClient returns the `*http.Client` to use for this `Headless` instance.
+func (h Headless) HTTPClient() *http.Client {
+	return h.Client
 }
 
 // Credentials returns back the set of credentials used for every request.
@@ -56,7 +57,7 @@ func (h Headless) InitializeCredentials() error {
 	if err != nil {
 		return err
 	}
-	resp, err := h.httpClient().PostForm(tokenURI.String(), url.Values{
+	resp, err := h.HTTPClient().PostForm(tokenURI.String(), url.Values{
 		"client_id":     {h.ApplicationID},
 		"client_secret": {h.ApplicationSecret},
 		"grant_type":    {"client_credentials"},

--- a/client/headless_client.go
+++ b/client/headless_client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -80,8 +79,7 @@ func (h Headless) InitializeCredentials(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	b, err := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
+	b, err := handleResp(ctx, resp)
 	if err != nil {
 		return err
 	}

--- a/client/headless_client.go
+++ b/client/headless_client.go
@@ -56,7 +56,7 @@ func (h Headless) InitializeCredentials() error {
 	if err != nil {
 		return err
 	}
-	resp, err := http.PostForm(tokenURI.String(), url.Values{
+	resp, err := h.httpClient().PostForm(tokenURI.String(), url.Values{
 		"client_id":     {h.ApplicationID},
 		"client_secret": {h.ApplicationSecret},
 		"grant_type":    {"client_credentials"},

--- a/client/headless_client.go
+++ b/client/headless_client.go
@@ -19,7 +19,7 @@ var _ Client = (*Headless)(nil)
 type Headless struct {
 	ApplicationID      string
 	ApplicationSecret  string
-	Error              error
+	Tenant             string
 	RefreshToken       string
 	RequestCredentials *RequestCredentials
 	Scopes             scopes.Scopes
@@ -31,6 +31,7 @@ func NewHeadless(applicationID string, applicationSecret string, scopes scopes.S
 	return &Headless{
 		ApplicationID:      applicationID,
 		ApplicationSecret:  applicationSecret,
+		Tenant:             "common",
 		RequestCredentials: &RequestCredentials{},
 		Scopes:             scopes,
 		Client:             http.DefaultClient,
@@ -54,7 +55,7 @@ func (h Headless) InitializeCredentials(ctx context.Context) error {
 	if h.RequestCredentials.AccessToken != "" && h.RequestCredentials.AccessTokenExpiresAt.After(time.Now()) {
 		return nil
 	}
-	tokenURI, err := url.Parse("https://login.microsoftonline.com/common/oauth2/v2.0/token")
+	tokenURI, err := url.Parse("https://login.microsoftonline.com/" + url.PathEscape(h.Tenant) + "/oauth2/v2.0/token")
 	if err != nil {
 		return err
 	}

--- a/client/headless_client.go
+++ b/client/headless_client.go
@@ -11,6 +11,8 @@ import (
 	"github.com/mhoc/msgoraph/scopes"
 )
 
+var _ Client = (*Headless)(nil)
+
 // Headless is used to authenticate requests in the context of a backend app. This is the most
 // common way for applications to authenticate with the api.
 type Headless struct {
@@ -20,6 +22,7 @@ type Headless struct {
 	RefreshToken       string
 	RequestCredentials *RequestCredentials
 	Scopes             scopes.Scopes
+	HTTPClient         *http.Client
 }
 
 // NewHeadless creates a new headless connection.
@@ -29,7 +32,12 @@ func NewHeadless(applicationID string, applicationSecret string, scopes scopes.S
 		ApplicationSecret:  applicationSecret,
 		RequestCredentials: &RequestCredentials{},
 		Scopes:             scopes,
+		HTTPClient:         http.DefaultClient,
 	}
+}
+
+func (h Headless) httpClient() *http.Client {
+	return h.HTTPClient
 }
 
 // Credentials returns back the set of credentials used for every request.

--- a/client/headless_client_test.go
+++ b/client/headless_client_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"testing"
 
 	"github.com/mhoc/msgoraph/scopes"
@@ -10,7 +11,7 @@ func TestHeadlessClientInitialization(t *testing.T) {
 	applicationID := ""
 	applicationSecret := ""
 	c := NewHeadless(applicationID, applicationSecret, scopes.All(scopes.PermissionTypeApplication))
-	err := c.InitializeCredentials()
+	err := c.InitializeCredentials(context.Background())
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/client/http.go
+++ b/client/http.go
@@ -30,7 +30,7 @@ func BasicGraphRequest(ctx context.Context, client Client, method string, url st
 	}
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %v", client.Credentials().AccessToken))
 	req.Header.Add("Content-Type", "application/json")
-	resp, err := client.httpClient().Do(req)
+	resp, err := client.HTTPClient().Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/client/http.go
+++ b/client/http.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/mhoc/msgoraph/common"
 )
@@ -84,4 +85,18 @@ func handleResp(ctx context.Context, resp *http.Response) ([]byte, error) {
 		return nil, *errResp.Error
 	}
 	return b, nil
+}
+
+// postForm is an alternative to `http.(*Client).PostForm` that allows to passing a `context.Context`.
+func postForm(ctx context.Context, client *http.Client, uri string, data url.Values) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, uri, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
 }

--- a/client/http.go
+++ b/client/http.go
@@ -43,6 +43,7 @@ func BasicGraphRequest(ctx context.Context, client Client, method string, url st
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 	return ioutil.ReadAll(resp.Body)
 }
 

--- a/client/web_client.go
+++ b/client/web_client.go
@@ -137,7 +137,7 @@ func (w *Web) RefreshCredentials() error {
 	if err != nil {
 		return err
 	}
-	resp, err := http.PostForm(tokenURI.String(), url.Values{
+	resp, err := w.httpClient().PostForm(tokenURI.String(), url.Values{
 		"client_id":     {w.ApplicationID},
 		"grant_type":    {"refresh_token"},
 		"redirect_uri":  {w.redirectURI()},
@@ -196,7 +196,7 @@ func (w *Web) setAccessToken() error {
 	if err != nil {
 		return err
 	}
-	resp, err := http.PostForm(tokenURI.String(), url.Values{
+	resp, err := w.httpClient().PostForm(tokenURI.String(), url.Values{
 		"client_id":     {w.ApplicationID},
 		"client_secret": {w.ApplicationSecret},
 		"code":          {w.AuthorizationCode},

--- a/client/web_client.go
+++ b/client/web_client.go
@@ -34,7 +34,7 @@ type Web struct {
 	RefreshToken       string
 	RequestCredentials *RequestCredentials
 	Scopes             scopes.Scopes
-	HTTPClient         *http.Client
+	Client             *http.Client
 }
 
 // NewWeb creates a new client.Web connection. To initialize the authentication on this, call
@@ -46,12 +46,13 @@ func NewWeb(applicationID string, applicationSecret string, redirectURIPort int,
 		LocalhostPort:      redirectURIPort,
 		RequestCredentials: &RequestCredentials{},
 		Scopes:             scopes,
-		HTTPClient:         http.DefaultClient,
+		Client:             http.DefaultClient,
 	}
 }
 
-func (w *Web) httpClient() *http.Client {
-	return w.HTTPClient
+// HTTPClient returns the `*http.Client` to use for this `*Web` instance.
+func (w *Web) HTTPClient() *http.Client {
+	return w.Client
 }
 
 // Credentials returns back the set of request credentials in this client. Conforms to the
@@ -137,7 +138,7 @@ func (w *Web) RefreshCredentials() error {
 	if err != nil {
 		return err
 	}
-	resp, err := w.httpClient().PostForm(tokenURI.String(), url.Values{
+	resp, err := w.HTTPClient().PostForm(tokenURI.String(), url.Values{
 		"client_id":     {w.ApplicationID},
 		"grant_type":    {"refresh_token"},
 		"redirect_uri":  {w.redirectURI()},
@@ -196,7 +197,7 @@ func (w *Web) setAccessToken() error {
 	if err != nil {
 		return err
 	}
-	resp, err := w.httpClient().PostForm(tokenURI.String(), url.Values{
+	resp, err := w.HTTPClient().PostForm(tokenURI.String(), url.Values{
 		"client_id":     {w.ApplicationID},
 		"client_secret": {w.ApplicationSecret},
 		"code":          {w.AuthorizationCode},

--- a/client/web_client.go
+++ b/client/web_client.go
@@ -63,7 +63,7 @@ func (w *Web) Credentials() *RequestCredentials {
 
 // InitializeCredentials starts an oauth login flow to retrieve an authorization code, then exchange
 // that authorization code for an access token and (if offline access is enabled) a refresh token.
-func (w *Web) InitializeCredentials() error {
+func (w *Web) InitializeCredentials(ctx context.Context) error {
 	err := w.setAuthorizationCode()
 	if err != nil {
 		return err
@@ -122,7 +122,7 @@ func (w *Web) redirectURI() string {
 
 // RefreshCredentials will attempt to refresh the access token if it is expired. This call will fail
 // if the original authorization was not made with a Offline scope provided.
-func (w *Web) RefreshCredentials() error {
+func (w *Web) RefreshCredentials(ctx context.Context) error {
 	if !w.Scopes.HasScope(scopes.DelegatedOfflineAccess) {
 		return fmt.Errorf("this web client was not configured for offline access and token refresh. to configure this, provide an offline scope during the initial client authorization")
 	}

--- a/client/web_client.go
+++ b/client/web_client.go
@@ -68,7 +68,7 @@ func (w *Web) InitializeCredentials(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	err = w.setAccessToken()
+	err = w.setAccessToken(ctx)
 	return err
 }
 
@@ -138,7 +138,7 @@ func (w *Web) RefreshCredentials(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	resp, err := w.HTTPClient().PostForm(tokenURI.String(), url.Values{
+	resp, err := postForm(ctx, w.HTTPClient(), tokenURI.String(), url.Values{
 		"client_id":     {w.ApplicationID},
 		"grant_type":    {"refresh_token"},
 		"redirect_uri":  {w.redirectURI()},
@@ -184,7 +184,7 @@ func (w *Web) RefreshCredentials(ctx context.Context) error {
 	return nil
 }
 
-func (w *Web) setAccessToken() error {
+func (w *Web) setAccessToken(ctx context.Context) error {
 	if w.AuthorizationCode == "" {
 		return fmt.Errorf("client.Web: no access code found in web client")
 	}
@@ -197,7 +197,7 @@ func (w *Web) setAccessToken() error {
 	if err != nil {
 		return err
 	}
-	resp, err := w.HTTPClient().PostForm(tokenURI.String(), url.Values{
+	resp, err := postForm(ctx, w.HTTPClient(), tokenURI.String(), url.Values{
 		"client_id":     {w.ApplicationID},
 		"client_secret": {w.ApplicationSecret},
 		"code":          {w.AuthorizationCode},

--- a/client/web_client.go
+++ b/client/web_client.go
@@ -16,6 +16,8 @@ import (
 	"github.com/mhoc/msgoraph/scopes"
 )
 
+var _ Client = (*Web)(nil)
+
 // Web is used to authenticate requests in the context of an online/user-facing app, such
 // as a website. This type of client is mostly useful for debugging or for command line apps where
 // the user configures their own app on the Microsoft Graph portal. In a normal web app, the
@@ -32,6 +34,7 @@ type Web struct {
 	RefreshToken       string
 	RequestCredentials *RequestCredentials
 	Scopes             scopes.Scopes
+	HTTPClient         *http.Client
 }
 
 // NewWeb creates a new client.Web connection. To initialize the authentication on this, call
@@ -43,7 +46,12 @@ func NewWeb(applicationID string, applicationSecret string, redirectURIPort int,
 		LocalhostPort:      redirectURIPort,
 		RequestCredentials: &RequestCredentials{},
 		Scopes:             scopes,
+		HTTPClient:         http.DefaultClient,
 	}
+}
+
+func (w *Web) httpClient() *http.Client {
+	return w.HTTPClient
 }
 
 // Credentials returns back the set of request credentials in this client. Conforms to the

--- a/client/web_client.go
+++ b/client/web_client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -108,8 +109,8 @@ func (w *Web) localServer() *http.Server {
 			// This will throw an error when we shutdown the server during the normal authorization flow
 			// So we try to catch that error, and only return the real error if it isn't the expected
 			// error.
-			if !strings.Contains(err.Error(), "Server closed") {
-				w.Error = fmt.Errorf("error on ListenAndServe: %v", err)
+			if !errors.Is(err, http.ErrServerClosed) {
+				w.Error = fmt.Errorf("error on ListenAndServe: %w", err)
 			}
 		}
 	}()

--- a/common/grapherror.go
+++ b/common/grapherror.go
@@ -1,0 +1,46 @@
+package common
+
+import "fmt"
+
+// GraphErrorResponse represents an error response from the MS Graph API.
+//
+// https://docs.microsoft.com/en-us/graph/errors
+// https://docs.oasis-open.org/odata/odata-json-format/v4.0/os/odata-json-format-v4.0-os.html#_Toc372793091
+type GraphErrorResponse struct {
+	Error *GraphError `json:"error"`
+}
+
+// GraphError is the structure within an MS Graph API error.
+//
+// https://docs.microsoft.com/en-us/graph/errors
+// https://docs.oasis-open.org/odata/odata-json-format/v4.0/os/odata-json-format-v4.0-os.html#_Toc372793091
+type GraphError struct {
+	Code       string                 `json:"code"`
+	Message    string                 `json:"message"`
+	Details    *GraphErrorDetails     `json:"details"`
+	InnerError map[string]interface{} `json:"innerError"` // The spec says "innererror" but MS returns "innerError"
+}
+
+var _ error = GraphError{}
+
+func (err GraphError) Error() string {
+	return fmt.Sprintf("%s: %s", err.Code, err.Message)
+}
+
+// Is adds support for `error.Is(error, error)`. If `target` is a `GraphError`, the `Code` fields
+// are compared.
+func (err GraphError) Is(target error) bool {
+	e, ok := target.(GraphError)
+	if !ok {
+		return false
+	}
+
+	return e.Code == err.Code
+}
+
+// GraphErrorDetails represents the `details` field of a graph API error response.
+type GraphErrorDetails struct {
+	Code    string  `json:"code"`
+	Message string  `json:"message"`
+	Target  *string `json:"target"`
+}

--- a/common/grapherror_test.go
+++ b/common/grapherror_test.go
@@ -1,0 +1,68 @@
+package common
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestGraphErrorIs(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		Name     string
+		Err      GraphError
+		Err2     error
+		ExpectIs bool
+	}{
+		{
+			Name:     "nil",
+			Err:      GraphError{},
+			Err2:     nil,
+			ExpectIs: false,
+		},
+		{
+			Name:     "other",
+			Err:      GraphError{},
+			Err2:     errors.New("an error"),
+			ExpectIs: false,
+		},
+		{
+			Name: "same error code",
+			Err: GraphError{
+				Code:    "code1",
+				Message: "err",
+			},
+			Err2: GraphError{
+				Code:    "code1",
+				Message: "another err",
+			},
+			ExpectIs: true,
+		},
+		{
+			Name: "different error code",
+			Err: GraphError{
+				Code:    "code1",
+				Message: "err",
+			},
+			Err2: GraphError{
+				Code:    "code2",
+				Message: "err",
+			},
+			ExpectIs: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			if errors.Is(testCase.Err, testCase.Err2) != testCase.ExpectIs {
+				t.Errorf(
+					"Expected %t but got %t for testing if errors.Is(%#v, %#v)",
+					testCase.ExpectIs,
+					!testCase.ExpectIs,
+					testCase.Err,
+					testCase.Err2,
+				)
+			}
+		})
+	}
+}

--- a/internal/doc.go
+++ b/internal/doc.go
@@ -1,3 +1,0 @@
-// Package internal contains logic which should rarely be accessed by consumers of this library,
-// primarily around forming HTTP/odata calls to the Microsoft Graph API.
-package internal

--- a/users/service.go
+++ b/users/service.go
@@ -1,12 +1,13 @@
 package users
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/mhoc/msgoraph/client"
-	"github.com/mhoc/msgoraph/internal"
 )
 
 // CreateUserRequest is all the available args you can set when creating a user.
@@ -81,7 +82,7 @@ type UpdateUserRequest struct {
 
 // CreateUser creates a new user in the tenant.
 func (s *ServiceContext) CreateUser(createUser CreateUserRequest) (User, error) {
-	body, err := internal.GraphRequest(s.client, "POST", "v1.0/users", nil, createUser)
+	body, err := client.GraphRequest(context.TODO(), s.client, http.MethodPost, "v1.0/users", nil, createUser)
 	var data GetUserResponse
 	err = json.Unmarshal(body, &data)
 	if err != nil {
@@ -93,7 +94,7 @@ func (s *ServiceContext) CreateUser(createUser CreateUserRequest) (User, error) 
 // DeleteUser deletes an existing user by id or principal name.
 func (s *ServiceContext) DeleteUser(userIDOrPrincipal string) error {
 	reqURL := fmt.Sprintf("v1.0/users/%v", userIDOrPrincipal)
-	_, err := internal.GraphRequest(s.client, "DELETE", reqURL, nil, nil)
+	_, err := client.GraphRequest(context.TODO(), s.client, http.MethodDelete, reqURL, nil, nil)
 	return err
 }
 
@@ -120,7 +121,7 @@ func (s *ServiceContext) GetUserWithFields(userIDOrPrincipal string, projection 
 	v := url.Values{}
 	v.Set("$select", selectFields)
 	reqURL := fmt.Sprintf("v1.0/users/%v", userIDOrPrincipal)
-	b, err := internal.GraphRequest(s.client, "GET", reqURL, v, nil)
+	b, err := client.GraphRequest(context.TODO(), s.client, http.MethodGet, reqURL, v, nil)
 	var data GetUserResponse
 	err = json.Unmarshal(b, &data)
 	if err != nil {
@@ -140,7 +141,7 @@ func (s *ServiceContext) ListUsers() ([]User, error) {
 // UserAllFields, or customize it depending on what you want.
 func (s *ServiceContext) ListUsersWithFields(projection []Field) ([]User, error) {
 	getUserPage := func(url string) ([]User, string, error) {
-		b, err := internal.BasicGraphRequest(s.client, "GET", url)
+		b, err := client.BasicGraphRequest(context.TODO(), s.client, http.MethodGet, url, nil)
 		var data ListUsersResponse
 		err = json.Unmarshal(b, &data)
 		if err != nil {
@@ -175,6 +176,6 @@ func (s *ServiceContext) ListUsersWithFields(projection []Field) ([]User, error)
 // to update.
 func (s *ServiceContext) UpdateUser(userIDOrPrincipal string, u UpdateUserRequest) error {
 	reqURL := fmt.Sprintf("v1.0/users/%v", userIDOrPrincipal)
-	_, err := internal.GraphRequest(s.client, "PATCH", reqURL, nil, u)
+	_, err := client.GraphRequest(context.TODO(), s.client, http.MethodPatch, reqURL, nil, u)
 	return err
 }

--- a/users/service.go
+++ b/users/service.go
@@ -81,8 +81,8 @@ type UpdateUserRequest struct {
 }
 
 // CreateUser creates a new user in the tenant.
-func (s *ServiceContext) CreateUser(createUser CreateUserRequest) (User, error) {
-	body, err := client.GraphRequest(context.TODO(), s.client, http.MethodPost, "v1.0/users", nil, createUser)
+func (s *ServiceContext) CreateUser(ctx context.Context, createUser CreateUserRequest) (User, error) {
+	body, err := client.GraphRequest(ctx, s.client, http.MethodPost, "v1.0/users", nil, createUser)
 	var data GetUserResponse
 	err = json.Unmarshal(body, &data)
 	if err != nil {
@@ -92,22 +92,22 @@ func (s *ServiceContext) CreateUser(createUser CreateUserRequest) (User, error) 
 }
 
 // DeleteUser deletes an existing user by id or principal name.
-func (s *ServiceContext) DeleteUser(userIDOrPrincipal string) error {
+func (s *ServiceContext) DeleteUser(ctx context.Context, userIDOrPrincipal string) error {
 	reqURL := fmt.Sprintf("v1.0/users/%v", userIDOrPrincipal)
-	_, err := client.GraphRequest(context.TODO(), s.client, http.MethodDelete, reqURL, nil, nil)
+	_, err := client.GraphRequest(ctx, s.client, http.MethodDelete, reqURL, nil, nil)
 	return err
 }
 
 // GetUser returns a single user by id or principal name, with the Microsoft default fields
 // provided, identical to those specified in UserDefaultFields.
-func (s *ServiceContext) GetUser(userIDOrPrincipal string) (User, error) {
-	return s.GetUserWithFields(userIDOrPrincipal, UserDefaultFields)
+func (s *ServiceContext) GetUser(ctx context.Context, userIDOrPrincipal string) (User, error) {
+	return s.GetUserWithFields(ctx, userIDOrPrincipal, UserDefaultFields)
 }
 
 // GetUserWithFields returns a single user by id or principal name. You need to specify a list of
 // fields you want to project on the user returned. You can specify UserDefaultFields or
 // UserAllFields, or customize it depending on what you want.
-func (s *ServiceContext) GetUserWithFields(userIDOrPrincipal string, projection []Field) (User, error) {
+func (s *ServiceContext) GetUserWithFields(ctx context.Context, userIDOrPrincipal string, projection []Field) (User, error) {
 	if len(projection) == 0 {
 		return User{}, fmt.Errorf("no fields provided in call to Users")
 	}
@@ -121,7 +121,7 @@ func (s *ServiceContext) GetUserWithFields(userIDOrPrincipal string, projection 
 	v := url.Values{}
 	v.Set("$select", selectFields)
 	reqURL := fmt.Sprintf("v1.0/users/%v", userIDOrPrincipal)
-	b, err := client.GraphRequest(context.TODO(), s.client, http.MethodGet, reqURL, v, nil)
+	b, err := client.GraphRequest(ctx, s.client, http.MethodGet, reqURL, v, nil)
 	var data GetUserResponse
 	err = json.Unmarshal(b, &data)
 	if err != nil {
@@ -132,16 +132,16 @@ func (s *ServiceContext) GetUserWithFields(userIDOrPrincipal string, projection 
 
 // ListUsers returns all users in the tenant, with each user projected with the Microsoft-defined
 // default fields identical to UserDefaultFields.
-func (s *ServiceContext) ListUsers() ([]User, error) {
-	return s.ListUsersWithFields(UserDefaultFields)
+func (s *ServiceContext) ListUsers(ctx context.Context) ([]User, error) {
+	return s.ListUsersWithFields(ctx, UserDefaultFields)
 }
 
 // ListUsersWithFields returns the users on a tenant's azure instance. You need to specify a list of
 // fields you want to project on the users returned. You can specify UserDefaultFields or
 // UserAllFields, or customize it depending on what you want.
-func (s *ServiceContext) ListUsersWithFields(projection []Field) ([]User, error) {
+func (s *ServiceContext) ListUsersWithFields(ctx context.Context, projection []Field) ([]User, error) {
 	getUserPage := func(url string) ([]User, string, error) {
-		b, err := client.BasicGraphRequest(context.TODO(), s.client, http.MethodGet, url, nil)
+		b, err := client.BasicGraphRequest(ctx, s.client, http.MethodGet, url, nil)
 		var data ListUsersResponse
 		err = json.Unmarshal(b, &data)
 		if err != nil {
@@ -174,8 +174,8 @@ func (s *ServiceContext) ListUsersWithFields(projection []Field) ([]User, error)
 // UpdateUser updates a user in the microsoft graph api, by userid or principal name, which is
 // usually their email address. You can provide as few or many fields in the request as you'd like
 // to update.
-func (s *ServiceContext) UpdateUser(userIDOrPrincipal string, u UpdateUserRequest) error {
+func (s *ServiceContext) UpdateUser(ctx context.Context, userIDOrPrincipal string, u UpdateUserRequest) error {
 	reqURL := fmt.Sprintf("v1.0/users/%v", userIDOrPrincipal)
-	_, err := client.GraphRequest(context.TODO(), s.client, http.MethodPatch, reqURL, nil, u)
+	_, err := client.GraphRequest(ctx, s.client, http.MethodPatch, reqURL, nil, u)
 	return err
 }

--- a/users/service.go
+++ b/users/service.go
@@ -33,15 +33,15 @@ type ListUsersResponse struct {
 	Value    []User `json:"value"`
 }
 
-// ServiceContext represents a namespace under which all of the operations against user-namespaced
+// Service represents a namespace under which all of the operations against user-namespaced
 // resources are accessed.
-type ServiceContext struct {
+type Service struct {
 	client client.Client
 }
 
-// Service creates a new users.ServiceContext with the given authentication credentials.
-func Service(client client.Client) *ServiceContext {
-	return &ServiceContext{client: client}
+// NewService creates a new `*Service` that will use the given `client.Client`.
+func NewService(client client.Client) *Service {
+	return &Service{client: client}
 }
 
 // UpdateUserRequest contains the request body to update a user.
@@ -81,7 +81,7 @@ type UpdateUserRequest struct {
 }
 
 // CreateUser creates a new user in the tenant.
-func (s *ServiceContext) CreateUser(ctx context.Context, createUser CreateUserRequest) (User, error) {
+func (s *Service) CreateUser(ctx context.Context, createUser CreateUserRequest) (User, error) {
 	body, err := client.GraphRequest(ctx, s.client, http.MethodPost, "/v1.0/users", nil, createUser)
 	var data GetUserResponse
 	err = json.Unmarshal(body, &data)
@@ -92,7 +92,7 @@ func (s *ServiceContext) CreateUser(ctx context.Context, createUser CreateUserRe
 }
 
 // DeleteUser deletes an existing user by id or principal name.
-func (s *ServiceContext) DeleteUser(ctx context.Context, userIDOrPrincipal string) error {
+func (s *Service) DeleteUser(ctx context.Context, userIDOrPrincipal string) error {
 	reqURL := "/v1.0/users/" + url.PathEscape(userIDOrPrincipal)
 	_, err := client.GraphRequest(ctx, s.client, http.MethodDelete, reqURL, nil, nil)
 	return err
@@ -100,14 +100,14 @@ func (s *ServiceContext) DeleteUser(ctx context.Context, userIDOrPrincipal strin
 
 // GetUser returns a single user by id or principal name, with the Microsoft default fields
 // provided, identical to those specified in UserDefaultFields.
-func (s *ServiceContext) GetUser(ctx context.Context, userIDOrPrincipal string) (User, error) {
+func (s *Service) GetUser(ctx context.Context, userIDOrPrincipal string) (User, error) {
 	return s.GetUserWithFields(ctx, userIDOrPrincipal, UserDefaultFields)
 }
 
 // GetUserWithFields returns a single user by id or principal name. You need to specify a list of
 // fields you want to project on the user returned. You can specify UserDefaultFields or
 // UserAllFields, or customize it depending on what you want.
-func (s *ServiceContext) GetUserWithFields(ctx context.Context, userIDOrPrincipal string, projection []Field) (User, error) {
+func (s *Service) GetUserWithFields(ctx context.Context, userIDOrPrincipal string, projection []Field) (User, error) {
 	query := s.selectFields(url.Values{}, projection)
 	reqURL := "/v1.0/users/" + url.PathEscape(userIDOrPrincipal)
 	b, err := client.GraphRequest(ctx, s.client, http.MethodGet, reqURL, query, nil)
@@ -119,7 +119,7 @@ func (s *ServiceContext) GetUserWithFields(ctx context.Context, userIDOrPrincipa
 	return data.User, nil
 }
 
-func (s *ServiceContext) selectFields(query url.Values, fields []Field) url.Values {
+func (s *Service) selectFields(query url.Values, fields []Field) url.Values {
 	if len(fields) == 0 {
 		return query
 	}
@@ -136,7 +136,7 @@ func (s *ServiceContext) selectFields(query url.Values, fields []Field) url.Valu
 
 // ListUsers returns all users in the tenant, with each user projected with the default fields
 // returned by the API.
-func (s *ServiceContext) ListUsers(ctx context.Context) ([]User, error) {
+func (s *Service) ListUsers(ctx context.Context) ([]User, error) {
 	return s.ListUsersWithFields(ctx, nil)
 }
 
@@ -144,7 +144,7 @@ func (s *ServiceContext) ListUsers(ctx context.Context) ([]User, error) {
 // used as the `$select` parameter to the API. You can specify `UserDefaultFields` or
 // `UserAllFields`, or customize it depending on what you want. If you specify no fields, the
 // API will returns its default fields.
-func (s *ServiceContext) ListUsersWithFields(ctx context.Context, projection []Field) ([]User, error) {
+func (s *Service) ListUsersWithFields(ctx context.Context, projection []Field) ([]User, error) {
 	query := s.selectFields(url.Values{}, projection)
 	usersURL, err := client.GraphAPIRootURL.Parse("/v1.0/users")
 	if err != nil {
@@ -166,7 +166,7 @@ func (s *ServiceContext) ListUsersWithFields(ctx context.Context, projection []F
 	return users, nil
 }
 
-func (s *ServiceContext) getUserPage(ctx context.Context, url string) ([]User, string, error) {
+func (s *Service) getUserPage(ctx context.Context, url string) ([]User, string, error) {
 	b, err := client.BasicGraphRequest(ctx, s.client, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, "", err
@@ -182,7 +182,7 @@ func (s *ServiceContext) getUserPage(ctx context.Context, url string) ([]User, s
 // UpdateUser updates a user in the microsoft graph api, by userid or principal name, which is
 // usually their email address. You can provide as few or many fields in the request as you'd like
 // to update.
-func (s *ServiceContext) UpdateUser(ctx context.Context, userIDOrPrincipal string, u UpdateUserRequest) error {
+func (s *Service) UpdateUser(ctx context.Context, userIDOrPrincipal string, u UpdateUserRequest) error {
 	reqURL := "/v1.0/users/" + url.PathEscape(userIDOrPrincipal)
 	_, err := client.GraphRequest(ctx, s.client, http.MethodPatch, reqURL, nil, u)
 	return err


### PR DESCRIPTION
* Exposed `GraphRequest` and `BasicGraphRequest` functions so not-yet-supported APIs can be manually called.
* Support `context` in `*GraphRequest`
* Removed redundant code in `GraphRequest` (now calls `BasicGraphRequst` after the inital request prep)